### PR TITLE
Handle additional Twilio errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,10 +87,10 @@ PLATFORMS
 
 DEPENDENCIES
   rack-test (~> 1.1)
-  rspec (~> 3.6)
+  rspec (~> 3)
   rspec_junit_formatter (~> 0.3)
   stealth (>= 2.0.0.beta)
   stealth-twilio!
 
 BUNDLED WITH
-   2.1.4
+   2.2.32

--- a/lib/stealth/services/twilio/client.rb
+++ b/lib/stealth/services/twilio/client.rb
@@ -42,9 +42,9 @@ module Stealth
             when /21211/ # Invalid 'To' Phone Number
               raise Stealth::Errors::InvalidSessionID
             when /21612/ # 'To' phone number is not currently reachable via SMS
-              raise Stealth::Errors::UserOptOut
+              raise Stealth::Errors::InvalidSessionID
             when /21614/ # 'To' number is not a valid mobile number
-              raise Stealth::Errors::UserOptOut
+              raise Stealth::Errors::InvalidSessionID
             when /30003/ # Unreachable destination handset
               raise Stealth::Errors::InvalidSessionID
             when /30004/ # Message Blocked
@@ -52,7 +52,7 @@ module Stealth
             when /30005/ # Unknown destination handset
               raise Stealth::Errors::InvalidSessionID
             when /30006/ # Landline or unreachable carrier
-              raise Stealth::Errors::UserOptOut
+              raise Stealth::Errors::InvalidSessionID
             when /30007/ # Message filtered
               raise Stealth::Errors::MessageFiltered
             when /30008/ # Unknown error 🤷‍♂️

--- a/lib/stealth/services/twilio/client.rb
+++ b/lib/stealth/services/twilio/client.rb
@@ -39,18 +39,24 @@ module Stealth
             case e.message
             when /21610/ # Attempt to send to unsubscribed recipient
               raise Stealth::Errors::UserOptOut
+            when /21211/ # Invalid 'To' Phone Number
+              raise Stealth::Errors::InvalidSessionID
             when /21612/ # 'To' phone number is not currently reachable via SMS
               raise Stealth::Errors::UserOptOut
             when /21614/ # 'To' number is not a valid mobile number
               raise Stealth::Errors::UserOptOut
-            when /30004/ # Message blocked
-              raise Stealth::Errors::UserOptOut
-            when /21211/ # Invalid 'To' Phone Number
-              raise Stealth::Errors::InvalidSessionID
             when /30003/ # Unreachable destination handset
               raise Stealth::Errors::InvalidSessionID
+            when /30004/ # Message Blocked
+              raise Stealth::Errors::MessageFiltered
             when /30005/ # Unknown destination handset
               raise Stealth::Errors::InvalidSessionID
+            when /30006/ # Landline or unreachable carrier
+              raise Stealth::Errors::UserOptOut
+            when /30007/ # Message filtered
+              raise Stealth::Errors::MessageFiltered
+            when /30008/ # Unknown error 🤷‍♂️
+              raise Stealth::Errors::UnknownServiceError
             else
               raise
             end


### PR DESCRIPTION
In https://github.com/hellostealth/stealth/pull/300, support was added for message filtering errors as well as "unknown" errors. This PR translates Twilio client errors into those new error types.

@matthewblack does this look correct? Think it's OK to make landline errors translate into opt outs?